### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 before_install:
   - pip install poetry==0.12.17
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
Test on Travis CI and add Trove classifier.

---

Thanks for the library! 

By the way, I just used this to see how the UK general election results would look using a proportional d'Hondt similar to that used in EU elections (with a single constituency).


```python
from voting import apportionment  # pip install voting


seats = 650

# Results with 649 of 650 declared:
# https://www.theguardian.com/politics/ng-interactive/2019/dec/12/uk-general-election-2019-full-results-live-labour-conservatives-tories

parties = [
    "Conservative",
    "Labour",
    "Scottish National Party",
    "Liberal Democrat",
    "Democratic Unionist Party",
    "Sinn Féin",
    "Plaid Cymru",
    "Social Democratic and Labour Party",
    "Green",
    "Alliance",
    "Brexit",
    "Ind",
    "Change",
    "Other",
]

votes = [
    13941200,
    10292054,
    1242372,
    3675342,
    244128,
    181853,
    153265,
    118737,
    864743,
    134115,
    642303,
    196843,
    10006,
    263556,
]

assignments = apportionment.dhondt(votes, seats)

parties = [party for _, party in sorted(zip(assignments, parties), reverse=True)]
assignments = sorted(assignments, reverse=True)

print("Seats\tParty")
print("-------------")

for i, party in enumerate(parties):
    print(f"{assignments[i]}\t{parties[i]}")
```

Outputs:

```
Seats	Party
-------------
285	Conservative
211	Labour
75	Liberal Democrat
25	Scottish National Party
17	Green
13	Brexit
5	Other
5	Democratic Unionist Party
4	Ind
3	Sinn Féin
3	Plaid Cymru
2	Social Democratic and Labour Party
2	Alliance
0	Change
```

Compare: https://www.theguardian.com/politics/ng-interactive/2019/dec/12/uk-general-election-2019-full-results-live-labour-conservatives-tories

